### PR TITLE
Make env_logger a dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,12 @@ categories = ["wasm", "api-bindings"]
 [dependencies]
 wapc = "0.10.1"
 log = "0.4.11"
-env_logger = "0.7"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 wasmtime = "0.19.0"
 wasmtime-wasi = "0.19.1"
 anyhow = "1.0.31"
 wasi-common = "0.19.1"
+
+[dev-dependencies]
+env_logger = "0.7"


### PR DESCRIPTION
env_logger seems to only be used in the example and the doc test, so should be a dev dependency.