### PR TITLE
Update to latest stable release of wasmtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ wapc = "0.10.1"
 log = "0.4.11"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
-wasmtime = "0.24.0"
-wasmtime-wasi = "0.24.0"
+wasmtime = "0.27.0"
+wasmtime-wasi = "0.27.0"
 anyhow = "1.0.31"
-wasi-common = "0.24.0"
-wasi-cap-std-sync = "0.24.0"
+wasi-common = "0.27.0"
+wasi-cap-std-sync = "0.27.0"
 cap-std = "0.13"
 
 [dev-dependencies]

--- a/src/modreg.rs
+++ b/src/modreg.rs
@@ -39,11 +39,11 @@ impl ModuleRegistry {
         Ok(ModuleRegistry {
             wasi_snapshot_preview1: wasmtime_wasi::snapshots::preview_1::Wasi::new(
                 store,
-                Rc::new(RefCell::new(cx1.build()?)),
+                Rc::new(RefCell::new(cx1.build())),
             ),
             wasi_unstable: wasmtime_wasi::snapshots::preview_0::Wasi::new(
                 store,
-                Rc::new(RefCell::new(cx2.build()?)),
+                Rc::new(RefCell::new(cx2.build())),
             ),
         })
     }


### PR DESCRIPTION
Update to wasmtime 0.27.0, this is required to address a security issue
inside of cranelift.

See [wasmtime's release notes](https://github.com/bytecodealliance/wasmtime/blob/v0.27.0/RELEASES.md#0270) for more details.

It would be great to tag a new release of wasmtime-provider once this is merged