### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/security-audit-cron.yml
+++ b/.github/workflows/security-audit-cron.yml
@@ -1,0 +1,12 @@
+name: Security audit cron job
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-audit-reactive.yml
+++ b/.github/workflows/security-audit-reactive.yml
@@ -1,0 +1,14 @@
+name: Security audit
+on:
+  push:
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,65 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/src/modreg.rs
+++ b/src/modreg.rs
@@ -50,8 +50,8 @@ impl ModuleRegistry {
 }
 
 pub(crate) fn compute_preopen_dirs(
-    dirs: &Vec<String>,
-    map_dirs: &Vec<(String, String)>,
+    dirs: &[String],
+    map_dirs: &[(String, String)],
 ) -> Result<Vec<(String, Dir)>, Box<dyn Error>> {
     let mut preopen_dirs = Vec::new();
 
@@ -66,7 +66,7 @@ pub(crate) fn compute_preopen_dirs(
     Ok(preopen_dirs)
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::vec_init_then_push)]
 pub(crate) fn compute_argv(module: PathBuf, module_args: Vec<String>) -> Vec<String> {
     let mut result = Vec::new();
 


### PR DESCRIPTION
I noticed there's no automation on this repository. This PR covers the basics, I hope you won't mind it :blush: 

Add the following GitHub actions to:

  * Run unit tests on PR and on push events
  * Look for security issues via `cargo audit` on a daily basis (cron)
  * Look for security issues via `cargo audit` whenever the Cargo.* file
    are changed